### PR TITLE
Remove ugly whitespaces from generator

### DIFF
--- a/lib/generators/devise_shibboleth_authenticatable/install_generator.rb
+++ b/lib/generators/devise_shibboleth_authenticatable/install_generator.rb
@@ -28,11 +28,11 @@ module DeviseShibbolethAuthenticatable
     
     def default_devise_settings
       settings = <<-eof
-  # ==> Shibboleth Configuration 
+  # ==> Shibboleth Configuration
   # config.shibboleth_logger = true
   # config.shibboleth_create_user = false
   # config.shibboleth_config = "\#{Rails.root}/config/shibboleth.yml"
-  
+
       eof
       if options.advanced?  
         settings << <<-eof  


### PR DESCRIPTION
The devise.rb generator is adding unwanted whitespaces. This commit prevents it. Nothing fancy.
